### PR TITLE
fix: ksuplaod component filename cannot contain & symbol

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dist/
 ts.out/
 types/
 package-lock.json
+.history/

--- a/src/components/base/KSUpload/mixins/base.ts
+++ b/src/components/base/KSUpload/mixins/base.ts
@@ -164,10 +164,12 @@ export default class Mixin extends Vue {
 
   private urlAddDownload(url, filename = '') {
     let str = url.split('#')[0];
+    // 对文件名进行编码，主要用于处理如&等特殊字符
+    const name = encodeURIComponent(filename);
     if (/\?/g.test(url)) {
-      str += `&download=${filename}`;
+      str += `&download=${name}`;
     } else {
-      str += `?download=${filename}`;
+      str += `?download=${name}`;
     }
     if (url.split('#')[1]) {
       str += `#${url.split('#')[1]}`;


### PR DESCRIPTION
 If user upload file name contains & symbol, the download file type will missing.